### PR TITLE
Added support for latestTestVersion (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ class App: Application() {
             VersionCheckConfig(
             appVersionName = BuildConfig.VERSION_NAME,
             appVersionCode = BuildConfig.VERSION_CODE,
-            url = "https://myservice.com/api/version" // <-- Change this URL
+            url = "https://myservice.com/api/version", // <-- Change this URL
+            packageDetails = DefaultPackageDetails(packageManager, packageName) // Optional, but required for latestTestVersion support
           )
         )
         

--- a/app/src/main/java/com/steamclock/versioncheckkotlinsample/App.kt
+++ b/app/src/main/java/com/steamclock/versioncheckkotlinsample/App.kt
@@ -1,10 +1,12 @@
 package com.steamclock.versioncheckkotlinsample
 
 import android.app.Application
+import android.content.pm.PackageManager
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.ProcessLifecycleOwner
 import com.steamclock.versioncheckkotlin.VersionCheck
 import com.steamclock.versioncheckkotlin.VersionCheckConfig
+import com.steamclock.versioncheckkotlin.interfaces.DefaultPackageDetails
 import com.steamclock.versioncheckkotlin.interfaces.DefaultUpgradeDialog
 import com.steamclock.versioncheckkotlin.interfaces.URLFetcher
 import kotlinx.coroutines.*
@@ -21,11 +23,12 @@ class App: Application() {
     private fun setupVersionCheck() {
         val versionChecker = VersionCheck(
             VersionCheckConfig(
-            appVersionName = BuildConfig.VERSION_NAME,
-            appVersionCode = BuildConfig.VERSION_CODE,
-            url = "https://doesn't_matter",
-            urlFetcher = MockURLFetcher
-          )
+                appVersionName = BuildConfig.VERSION_NAME,
+                appVersionCode = BuildConfig.VERSION_CODE,
+                url = "https://doesn't_matter",
+                urlFetcher = MockURLFetcher,
+                packageDetails = DefaultPackageDetails(packageManager, packageName)
+            )
         )
         val upgradeDialog = DefaultUpgradeDialog(versionChecker.displayStateFlow)
 

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/VersionCheckConfig.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/VersionCheckConfig.kt
@@ -1,14 +1,12 @@
 package com.steamclock.versioncheckkotlin
 
-import com.steamclock.versioncheckkotlin.interfaces.DefaultVersionDataConverter
-import com.steamclock.versioncheckkotlin.interfaces.NetworkURLFetcher
-import com.steamclock.versioncheckkotlin.interfaces.URLFetcher
-import com.steamclock.versioncheckkotlin.interfaces.VersionDataConverter
+import com.steamclock.versioncheckkotlin.interfaces.*
 
 data class VersionCheckConfig(
     val appVersionName: String,
     val appVersionCode: Int,
     val url: String,
     val urlFetcher: URLFetcher = NetworkURLFetcher,
-    val versionDataConverter: VersionDataConverter = DefaultVersionDataConverter
+    val versionDataConverter: VersionDataConverter = DefaultVersionDataConverter,
+    val packageDetails: PackageDetails? = null
 )

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/interfaces/PackageDetails.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/interfaces/PackageDetails.kt
@@ -1,0 +1,25 @@
+package com.steamclock.versioncheckkotlin.interfaces
+
+import android.content.pm.PackageManager
+import android.os.Build
+
+interface PackageDetails {
+    fun wasSideLoaded(): Boolean
+}
+
+@Suppress("DEPRECATION")
+class DefaultPackageDetails(private val pm: PackageManager, private val name: String): PackageDetails {
+    override fun wasSideLoaded(): Boolean {
+        return try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val info = pm.getInstallSourceInfo(name)
+                info.installingPackageName == null
+            } else {
+                val installer = pm.getInstallerPackageName(name)
+                installer == null
+            }
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/models/VersionData.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/models/VersionData.kt
@@ -33,6 +33,14 @@ data class PlatformVersionData(
             }
         }
     }
+
+    fun shouldUpdateForTesting(other: Version): Boolean {
+        return if (latestTestVersion == null) {
+            false
+        } else {
+            other < latestTestVersion
+        }
+    }
 }
 
 data class VersionData(

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/PlatformVersionDataTest.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/PlatformVersionDataTest.kt
@@ -22,6 +22,11 @@ class PlatformVersionDataTest {
         blockedVersions = setOf(Version("@400"), Version("2.2.1@300"), Version("2.3@900")),
         latestTestVersion = null)
 
+    private val latestTestVersion = PlatformVersionData(
+        minimumVersion = Version("1.2.0"),
+        blockedVersions = setOf(),
+        latestTestVersion = Version("1.4"))
+
     @Test
     fun testContainsBlockedVersion() {
         val versionNotBlocked = Version("1.2.3@900")
@@ -52,5 +57,13 @@ class PlatformVersionDataTest {
 
         shouldBeTrue.forEach { assertTrue(it.first.containsBlockedVersion(it.second)) }
         shouldNotFalse.forEach { assertFalse(it.first.containsBlockedVersion(it.second)) }
+    }
+
+    @Test
+    fun testShouldUpdateForTesting() {
+        assertTrue(latestTestVersion.shouldUpdateForTesting(Version("1.2.2@200")))
+        assertTrue(latestTestVersion.shouldUpdateForTesting(Version("1.3@400")))
+        assertFalse(latestTestVersion.shouldUpdateForTesting(Version("1.4.0@600")))
+        assertFalse(latestTestVersion.shouldUpdateForTesting(Version("2.4.0@800")))
     }
 }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
@@ -43,7 +43,7 @@ class VersionCheckTest {
      * On version OK
      */
     @Test
-    fun `Status set to Allowed when app version is ok`() = runBlocking {
+    fun `Status set to VersionAllowed when app version is ok`() = runBlocking {
         versionCheck = VersionCheck(TestConstants.VersionCheckConfig.validApp)
         versionCheck.statusFlow.test {
             assertEquals(Status.Unknown, awaitItem())
@@ -68,7 +68,7 @@ class VersionCheckTest {
      * When app version too old
      */
     @Test
-    fun `Status set to Disallowed when app version older`() = runBlocking {
+    fun `Status set to VersionDisallowed when app version older`() = runBlocking {
         versionCheck = VersionCheck(TestConstants.VersionCheckConfig.appOldVersion)
         versionCheck.statusFlow.test {
             assertEquals(Status.Unknown, awaitItem())
@@ -93,7 +93,7 @@ class VersionCheckTest {
      * When app version is blocked
      */
     @Test
-    fun `Status set to Disallowed when app version is blocked`() = runBlocking {
+    fun `Status set to VersionDisallowed when app version is blocked`() = runBlocking {
         versionCheck = VersionCheck(TestConstants.VersionCheckConfig.appVersionBlocked)
         versionCheck.statusFlow.test {
             assertEquals(Status.Unknown, awaitItem())
@@ -163,4 +163,57 @@ class VersionCheckTest {
             confirmLastEmit()
         }
     }
+
+    /**
+     * LatestTest Available
+     */
+    @Test
+    fun `Status set to VersionAllowed when latestTestVersion available and app side loaded`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.latestTestVersionAvailable)
+        versionCheck.statusFlow.test {
+            assertEquals(Status.Unknown, awaitItem())
+            versionCheck.runVersionCheck()
+            assertEquals(Status.VersionAllowed, awaitItem())
+            confirmLastEmit()
+        }
+    }
+
+    // todo need to flip assertEquals prop order
+
+    @Test
+    fun `DisplayState set to SuggestUpdate when latestTestVersion available and app side loaded`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.latestTestVersionAvailable)
+        versionCheck.displayStateFlow.test {
+            assertEquals(awaitItem(),DisplayState.Clear)
+            versionCheck.runVersionCheck()
+            assertEquals(awaitItem(),DisplayState.SuggestUpdate)
+            confirmLastEmit()
+        }
+    }
+
+    /**
+     * LatestTest Not Applicable
+     */
+    @Test
+    fun `Status set to VersionAllowed when latestTestVersion available but not applicable`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.latestTestVersionNotApplicable)
+        versionCheck.statusFlow.test {
+            assertEquals(Status.Unknown, awaitItem())
+            versionCheck.runVersionCheck()
+            assertEquals(Status.VersionAllowed, awaitItem())
+            confirmLastEmit()
+        }
+    }
+
+    @Test
+    fun `DisplayState set to Clear (only once) when latestTestVersion available but not applicable`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.latestTestVersionNotApplicable)
+        versionCheck.displayStateFlow.test {
+            assertEquals(awaitItem(),DisplayState.Clear)
+            versionCheck.runVersionCheck()
+            // DisplayState should not get updated/emit
+            confirmLastEmit()
+        }
+    }
+
 }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/MockPackageDetails.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/MockPackageDetails.kt
@@ -1,0 +1,13 @@
+package com.steamclock.versioncheckkotlin.utils
+
+import com.steamclock.versioncheckkotlin.interfaces.PackageDetails
+
+object MockPackageDetails {
+    object WasSideLoaded: PackageDetails {
+        override fun wasSideLoaded() = true
+    }
+
+    object WasNotSideLoaded: PackageDetails {
+        override fun wasSideLoaded() = false
+    }
+}

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
@@ -87,5 +87,21 @@ object TestConstants {
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.invalidVersionDataJson)
         )
+
+        val latestTestVersionAvailable = VersionCheckConfig(
+            appVersionName = "1.3",
+            appVersionCode = 400,
+            url = "https://this-doesnt-matter",
+            urlFetcher = MockURLFetcher(MockJson.validVersionDataJson),
+            packageDetails = MockPackageDetails.WasSideLoaded
+        )
+
+        val latestTestVersionNotApplicable = VersionCheckConfig(
+            appVersionName = "1.3",
+            appVersionCode = 400,
+            url = "https://this-doesnt-matter",
+            urlFetcher = MockURLFetcher(MockJson.validVersionDataJson),
+            packageDetails = MockPackageDetails.WasNotSideLoaded
+        )
     }
 }


### PR DESCRIPTION
### Summary of Problem:
Users that are deemed as being on test builds may be "Suggested" to update; iOS supports this but Android did not yet.

### Proposed Solution:
Add in the check on Android; currently I am deeming that a user is a "tester" if the app was side loaded, as I believe installs from Bitrise are side loaded.

### Testing Steps:
Since this requires package details, it is easiest to test by running the created unit tests.