### PR TITLE
Added support for DisplayState.DevelopmentFailure (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ class App: Application() {
     private fun setupVersionCheck() {
         val versionChecker = VersionCheck(
             VersionCheckConfig(
-            appVersionName = BuildConfig.VERSION_NAME,
-            appVersionCode = BuildConfig.VERSION_CODE,
-            url = "https://myservice.com/api/version", // <-- Change this URL
-            packageDetails = DefaultPackageDetails(packageManager, packageName) // Optional, but required for latestTestVersion support
+             packageDetails = DefaultPackageDetails(
+                    BuildConfig.VERSION_NAME,
+                    BuildConfig.VERSION_CODE,
+                    packageManager,
+                    packageName),
+            url = "https://myservice.com/api/version" // <-- Change this URL
           )
         )
         

--- a/app/src/main/java/com/steamclock/versioncheckkotlinsample/App.kt
+++ b/app/src/main/java/com/steamclock/versioncheckkotlinsample/App.kt
@@ -9,6 +9,7 @@ import com.steamclock.versioncheckkotlin.VersionCheckConfig
 import com.steamclock.versioncheckkotlin.interfaces.DefaultPackageDetails
 import com.steamclock.versioncheckkotlin.interfaces.DefaultUpgradeDialog
 import com.steamclock.versioncheckkotlin.interfaces.URLFetcher
+import com.steamclock.versioncheckkotlin.models.Version
 import kotlinx.coroutines.*
 import java.net.URL
 import kotlin.random.Random
@@ -23,11 +24,13 @@ class App: Application() {
     private fun setupVersionCheck() {
         val versionChecker = VersionCheck(
             VersionCheckConfig(
-                appVersionName = BuildConfig.VERSION_NAME,
-                appVersionCode = BuildConfig.VERSION_CODE,
+                packageDetails = DefaultPackageDetails(
+                    BuildConfig.VERSION_NAME,
+                    BuildConfig.VERSION_CODE,
+                    packageManager,
+                    packageName),
                 url = "https://doesn't_matter",
-                urlFetcher = MockURLFetcher,
-                packageDetails = DefaultPackageDetails(packageManager, packageName)
+                urlFetcher = MockURLFetcher
             )
         )
         val upgradeDialog = DefaultUpgradeDialog(versionChecker.displayStateFlow)

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/UpgradeDialog.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/UpgradeDialog.kt
@@ -61,6 +61,15 @@ class DefaultUpgradeDialog(private val versionDisplayState: StateFlow<DisplaySta
                     canDismiss = true
                 )
             }
+            is DisplayState.DevelopmentFailure -> {
+                createBasicDialog(
+                    context,
+                    "Version Check Error",
+                    state.reason,
+                    requiresUpdate = false,
+                    canDismiss = true
+                )
+            }
             // todo 2021-09 Handle down for maintenance
             else -> {
                 dialog?.dismiss()

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/VersionCheckConfig.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/VersionCheckConfig.kt
@@ -3,10 +3,8 @@ package com.steamclock.versioncheckkotlin
 import com.steamclock.versioncheckkotlin.interfaces.*
 
 data class VersionCheckConfig(
-    val appVersionName: String,
-    val appVersionCode: Int,
+    val packageDetails: PackageDetails,
     val url: String,
     val urlFetcher: URLFetcher = NetworkURLFetcher,
     val versionDataConverter: VersionDataConverter = DefaultVersionDataConverter,
-    val packageDetails: PackageDetails? = null
 )

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/interfaces/PackageDetails.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/interfaces/PackageDetails.kt
@@ -19,8 +19,11 @@ class DefaultPackageDetails(
 
     override fun getAppVersion() = Version(appVersionName, appVersionCode)
 
+    /**
+     * By default we assume that all builds with code 1 are "development" builds.
+     */
     override fun isDevelopmentBuild(): Boolean {
-        return true
+        return appVersionCode == 1
     }
 
     /**

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/interfaces/PackageDetails.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/interfaces/PackageDetails.kt
@@ -2,20 +2,38 @@ package com.steamclock.versioncheckkotlin.interfaces
 
 import android.content.pm.PackageManager
 import android.os.Build
+import com.steamclock.versioncheckkotlin.models.Version
 
 interface PackageDetails {
-    fun wasSideLoaded(): Boolean
+    fun getAppVersion(): Version
+    fun isDevelopmentBuild(): Boolean
+    fun areTestUpdatesSupported(): Boolean
 }
 
 @Suppress("DEPRECATION")
-class DefaultPackageDetails(private val pm: PackageManager, private val name: String): PackageDetails {
-    override fun wasSideLoaded(): Boolean {
+class DefaultPackageDetails(
+    private val appVersionName: String,
+    private val appVersionCode: Int,
+    private val packageManager: PackageManager,
+    private val packageName: String): PackageDetails {
+
+    override fun getAppVersion() = Version(appVersionName, appVersionCode)
+
+    override fun isDevelopmentBuild(): Boolean {
+        return true
+    }
+
+    /**
+     * By default we assume that all apps that do not come from an official installer are "side
+     * loaded" and that side loaded apps are able to receive test updates.
+     */
+    override fun areTestUpdatesSupported(): Boolean {
         return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-                val info = pm.getInstallSourceInfo(name)
+                val info = packageManager.getInstallSourceInfo(packageName)
                 info.installingPackageName == null
             } else {
-                val installer = pm.getInstallerPackageName(name)
+                val installer = packageManager.getInstallerPackageName(packageName)
                 installer == null
             }
         } catch (e: Exception) {

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/models/DisplayState.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/models/DisplayState.kt
@@ -5,5 +5,5 @@ sealed class DisplayState {
     object SuggestUpdate: DisplayState()
     object ForceUpdate: DisplayState()
     object DownForMaintenance: DisplayState()
-    class DevelopmentFailure(reason: String): DisplayState()
+    class DevelopmentFailure(val reason: String): DisplayState()
 }

--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/models/Version.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/models/Version.kt
@@ -4,7 +4,22 @@ import com.steamclock.versioncheckkotlin.VersionCheckException
 import java.lang.Exception
 import kotlin.math.max
 
-class Version(string: String): Comparable<Version> {
+class Version: Comparable<Version> {
+
+    /**
+     * ex. "2021.6" and "400"
+     * versionName == marketing name
+     */
+    constructor(versionName: String, buildCode: Int) {
+        initWith(versionName, buildCode.toString())
+    }
+
+    /**
+     * ex. "2021.6.2-test@400"
+     */
+    constructor(fullStr: String) {
+        initWith(fullStr)
+    }
 
     var marketingComponents: IntArray = intArrayOf()
         private set
@@ -28,10 +43,6 @@ class Version(string: String): Comparable<Version> {
     //---------------------------------------------------------------------------------
     // Initialization
     //---------------------------------------------------------------------------------
-    init {
-        initWith(string)
-    }
-
     @Throws(VersionCheckException::class)
     private fun initWith(marketing: String?, buildStr: String?) {
         // Build

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
@@ -139,6 +139,17 @@ class VersionCheckTest {
         }
     }
 
+    @Test
+    fun `DisplayState set to DevelopmentFailure when json is malformed and is development build`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.jsonMalformedDevelopmentBuild)
+        versionCheck.displayStateFlow.test {
+            assertEquals(awaitItem(),DisplayState.Clear)
+            versionCheck.runVersionCheck()
+            assertTrue(awaitItem() is DisplayState.DevelopmentFailure)
+            confirmLastEmit()
+        }
+    }
+
     /**
      * Json valid, but missing Android data
      */
@@ -160,6 +171,17 @@ class VersionCheckTest {
             assertEquals(awaitItem(),DisplayState.Clear)
             versionCheck.runVersionCheck()
             // DisplayState should not get updated/emit
+            confirmLastEmit()
+        }
+    }
+
+    @Test
+    fun `DisplayState set to DevelopmentFailure when json missing android property and is development build`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.jsonMissingAndroidDevelopmentBuild)
+        versionCheck.displayStateFlow.test {
+            assertEquals(awaitItem(),DisplayState.Clear)
+            versionCheck.runVersionCheck()
+            assertTrue(awaitItem() is DisplayState.DevelopmentFailure)
             confirmLastEmit()
         }
     }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/MockPackageDetails.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/MockPackageDetails.kt
@@ -1,13 +1,30 @@
 package com.steamclock.versioncheckkotlin.utils
 
 import com.steamclock.versioncheckkotlin.interfaces.PackageDetails
+import com.steamclock.versioncheckkotlin.models.Version
 
 object MockPackageDetails {
-    object WasSideLoaded: PackageDetails {
-        override fun wasSideLoaded() = true
+    class IsDevelopmentBuild(private val appVersionName: String, private val appVersionCode: Int): PackageDetails {
+        override fun getAppVersion() = Version(appVersionName, appVersionCode)
+        override fun isDevelopmentBuild() = true
+        override fun areTestUpdatesSupported() = false
     }
 
-    object WasNotSideLoaded: PackageDetails {
-        override fun wasSideLoaded() = false
+    class IsNotDevelopmentBuild(private val appVersionName: String, private val appVersionCode: Int): PackageDetails {
+        override fun getAppVersion() = Version(appVersionName, appVersionCode)
+        override fun isDevelopmentBuild() = false
+        override fun areTestUpdatesSupported() = false
+    }
+
+    class TestUpdatesSupported(private val appVersionName: String, private val appVersionCode: Int): PackageDetails {
+        override fun getAppVersion() = Version(appVersionName, appVersionCode)
+        override fun isDevelopmentBuild() = false
+        override fun areTestUpdatesSupported() = true
+    }
+
+    class TestUpdatesNotSupported(private val appVersionName: String, private val appVersionCode: Int): PackageDetails {
+        override fun getAppVersion() = Version(appVersionName, appVersionCode)
+        override fun isDevelopmentBuild() = false
+        override fun areTestUpdatesSupported() = false
     }
 }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
@@ -1,6 +1,8 @@
 package com.steamclock.versioncheckkotlin.utils
 
 import com.steamclock.versioncheckkotlin.VersionCheckConfig
+import com.steamclock.versioncheckkotlin.interfaces.DefaultPackageDetails
+import com.steamclock.versioncheckkotlin.interfaces.PackageDetails
 
 object TestConstants {
 
@@ -47,61 +49,75 @@ object TestConstants {
     object VersionCheckConfig {
         // Test Config setups
         val validApp = VersionCheckConfig(
-            appVersionName = "1.1",
-            appVersionCode = 400,
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.1",
+                appVersionCode = 400
+            ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.validVersionDataJson)
         )
 
         val appOldVersion = VersionCheckConfig(
-            appVersionName = "1.0",
-            appVersionCode = 400,
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.0",
+                appVersionCode = 400
+            ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.validVersionDataJson)
         )
 
         val appVersionBlocked = VersionCheckConfig(
-            appVersionName = "1.2.1",
-            appVersionCode = 400,
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.2.1",
+                appVersionCode = 400
+            ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.validVersionDataJson)
         )
 
         val appBuildBlocked = VersionCheckConfig(
-            appVersionName = "1.1",
-            appVersionCode = 301,
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.1",
+                appVersionCode = 301
+            ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.validVersionDataJson)
         )
 
         val jsonMalformed = VersionCheckConfig(
-            appVersionName = "1.1",
-            appVersionCode = 301,
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.1",
+                appVersionCode = 301
+            ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.malformedJson)
         )
 
         val jsonMissingAndroid = VersionCheckConfig(
-            appVersionName = "1.1",
-            appVersionCode = 301,
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.1",
+                appVersionCode = 301
+            ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.invalidVersionDataJson)
         )
 
         val latestTestVersionAvailable = VersionCheckConfig(
-            appVersionName = "1.3",
-            appVersionCode = 400,
+            packageDetails = MockPackageDetails.TestUpdatesSupported(
+                appVersionName = "1.3",
+                appVersionCode = 400
+            ),
             url = "https://this-doesnt-matter",
-            urlFetcher = MockURLFetcher(MockJson.validVersionDataJson),
-            packageDetails = MockPackageDetails.WasSideLoaded
+            urlFetcher = MockURLFetcher(MockJson.validVersionDataJson)
         )
 
         val latestTestVersionNotApplicable = VersionCheckConfig(
-            appVersionName = "1.3",
-            appVersionCode = 400,
+            packageDetails = MockPackageDetails.TestUpdatesNotSupported(
+                appVersionName = "1.3",
+                appVersionCode = 400
+            ),
             url = "https://this-doesnt-matter",
-            urlFetcher = MockURLFetcher(MockJson.validVersionDataJson),
-            packageDetails = MockPackageDetails.WasNotSideLoaded
+            urlFetcher = MockURLFetcher(MockJson.validVersionDataJson)
         )
     }
 }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
@@ -93,8 +93,26 @@ object TestConstants {
             urlFetcher = MockURLFetcher(MockJson.malformedJson)
         )
 
+        val jsonMalformedDevelopmentBuild = VersionCheckConfig(
+            packageDetails = MockPackageDetails.IsDevelopmentBuild(
+                appVersionName = "1.1",
+                appVersionCode = 301
+            ),
+            url = "https://this-doesnt-matter",
+            urlFetcher = MockURLFetcher(MockJson.malformedJson)
+        )
+
         val jsonMissingAndroid = VersionCheckConfig(
             packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.1",
+                appVersionCode = 301
+            ),
+            url = "https://this-doesnt-matter",
+            urlFetcher = MockURLFetcher(MockJson.invalidVersionDataJson)
+        )
+
+        val jsonMissingAndroidDevelopmentBuild = VersionCheckConfig(
+            packageDetails = MockPackageDetails.IsDevelopmentBuild(
                 appVersionName = "1.1",
                 appVersionCode = 301
             ),


### PR DESCRIPTION
### Related Issue: #17


### Summary of Problem:
iOS has support for showing failure warnings on "development" builds.

### Proposed Solution:
Augment the `PackageDetails` interface to help give us more context about a build and allows the calling application more control over what should be considered a test or development build:
* Renamed isSideLoaded to be more descriptive: `areTestUpdatesSupported`
* Added `getVersion`: app version data now stored in this class
* Added `isDevelopmentBuild`: Indicates if the build should receive development warnings

`DefaultPackageDetails` now uses the version code to determine if the build is a development build or not; since gradle files default code to be 1, and since we are using our CI tools to update build codes, we can assume for now that all codes of 1 are coming from local development builds.

### Testing Steps:
Right now the sample app is not set to test this, but I manually malformed the test json it was using and then verified that a dismissible warning dialog was shown to me on app launch.  I changed the local build code to 2, re-ran the app and then verified that the development warning dialog did not show.

### Screenshots:
![image](https://user-images.githubusercontent.com/5217641/136083961-24758d07-2236-46b9-9459-25ee4707ee69.png)