### PR TITLE
DefaultUpgradeDialog now supports DisplayState.DownForMaintenance (#9)

### DIFF
--- a/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/UpgradeDialog.kt
+++ b/versioncheckkotlin/src/main/java/com/steamclock/versioncheckkotlin/UpgradeDialog.kt
@@ -70,6 +70,15 @@ class DefaultUpgradeDialog(private val versionDisplayState: StateFlow<DisplaySta
                     canDismiss = true
                 )
             }
+            is DisplayState.DownForMaintenance -> {
+                createBasicDialog(
+                    context,
+                    "Down for Maintenance",
+                    "The server is currently down for maintenance. Please check back later.",
+                    requiresUpdate = false,
+                    canDismiss = false
+                )
+            }
             // todo 2021-09 Handle down for maintenance
             else -> {
                 dialog?.dismiss()

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
@@ -238,4 +238,29 @@ class VersionCheckTest {
         }
     }
 
+    /**
+     * Server Maintenance
+     */
+    @Test
+    fun `Status still set to VersionAllowed when the server is down for maintenance`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.serverMaintenanceActive)
+        versionCheck.statusFlow.test {
+            assertEquals(Status.Unknown, awaitItem())
+            versionCheck.runVersionCheck()
+            assertEquals(Status.VersionAllowed, awaitItem())
+            confirmLastEmit()
+        }
+    }
+
+    @Test
+    fun `DisplayState set to DownForMaintenance when the server is down for maintenance`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.serverMaintenanceActive)
+        versionCheck.displayStateFlow.test {
+            assertEquals(awaitItem(),DisplayState.Clear)
+            versionCheck.runVersionCheck()
+            assertEquals(awaitItem(),DisplayState.DownForMaintenance)
+            confirmLastEmit()
+        }
+    }
+
 }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/VersionCheckTest.kt
@@ -263,4 +263,30 @@ class VersionCheckTest {
         }
     }
 
+    /**
+     * Server Force Version Update
+     */
+    @Test
+    fun `Status still set to VersionDisallowed when the serverForceVersionFailure flag is active`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.serverForceVersionFailureActive)
+        versionCheck.statusFlow.test {
+            assertEquals(Status.Unknown, awaitItem())
+            versionCheck.runVersionCheck()
+            assertEquals(Status.VersionDisallowed, awaitItem())
+            confirmLastEmit()
+        }
+    }
+
+    @Test
+    fun `DisplayState set to ForceUpdate when the serverForceVersionFailure flag is active`() = runBlocking {
+        versionCheck = VersionCheck(TestConstants.VersionCheckConfig.serverForceVersionFailureActive)
+        versionCheck.displayStateFlow.test {
+            assertEquals(awaitItem(),DisplayState.Clear)
+            versionCheck.runVersionCheck()
+            assertEquals(awaitItem(),DisplayState.ForceUpdate)
+            confirmLastEmit()
+        }
+    }
+
+
 }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
@@ -61,6 +61,23 @@ object TestConstants {
             "serverMaintenance": true
         }
         """
+
+        const val serverForceVersionFailureActive = """
+        {
+            "ios" : {
+                "minimumVersion": "1.1",
+                "blockedVersions": ["1.2.0", "1.2.1", "@301"],
+                "latestTestVersion": "1.4.2@400"
+            },
+            "android" : {
+                "minimumVersion": "1.1",
+                "blockedVersions": ["1.2.0", "1.2.1", "@301"],
+                "latestTestVersion": "1.4.2@400"
+            },
+            "serverForceVersionFailure": true,
+            "serverMaintenance": false
+        }
+        """
     }
 
     object VersionCheckConfig {
@@ -162,6 +179,15 @@ object TestConstants {
             ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.serverMaintenanceActive)
+        )
+
+        val serverForceVersionFailureActive = VersionCheckConfig(
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.5",
+                appVersionCode = 400
+            ),
+            url = "https://this-doesnt-matter",
+            urlFetcher = MockURLFetcher(MockJson.serverForceVersionFailureActive)
         )
     }
 }

--- a/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
+++ b/versioncheckkotlin/src/test/java/com/steamclock/versioncheckkotlin/utils/TestConstants.kt
@@ -44,6 +44,23 @@ object TestConstants {
             "serverMaintenance": false
         }
         """
+
+        const val serverMaintenanceActive = """
+        {
+            "ios" : {
+                "minimumVersion": "1.1",
+                "blockedVersions": ["1.2.0", "1.2.1", "@301"],
+                "latestTestVersion": "1.4.2@400"
+            },
+            "android" : {
+                "minimumVersion": "1.1",
+                "blockedVersions": ["1.2.0", "1.2.1", "@301"],
+                "latestTestVersion": "1.4.2@400"
+            },
+            "serverForceVersionFailure": false,
+            "serverMaintenance": true
+        }
+        """
     }
 
     object VersionCheckConfig {
@@ -136,6 +153,15 @@ object TestConstants {
             ),
             url = "https://this-doesnt-matter",
             urlFetcher = MockURLFetcher(MockJson.validVersionDataJson)
+        )
+
+        val serverMaintenanceActive = VersionCheckConfig(
+            packageDetails = MockPackageDetails.IsNotDevelopmentBuild(
+                appVersionName = "1.3",
+                appVersionCode = 400
+            ),
+            url = "https://this-doesnt-matter",
+            urlFetcher = MockURLFetcher(MockJson.serverMaintenanceActive)
         )
     }
 }


### PR DESCRIPTION
### Related Issue: #9 


### Summary of Problem:
We are correctly returning the DownForMaintenance state, but the dialog was not responding to it.

### Proposed Solution:
Add a case for DownForMaintenance in DefaultDialogDisplay; grabbed text from iOS project

### Testing Steps:
Tested by manually changing the JSON in the sample app and then making sure that the correct dialog showed and it could not be dismissed.

I have added #24 to augment the sample app to make testing these cases easier.

### Screenshots:
![image](https://user-images.githubusercontent.com/5217641/136106013-95002d05-3e98-4bc0-a8df-c08cb5befe7d.png)

